### PR TITLE
Restrict cookie length

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -20,17 +20,18 @@ Rack::ParamToCookie is a rack middleware that extracts request parameters from r
 In a Rails app, you can add it as middleware in +config/application.rb+. For a parameter called +ref+, the basic usage is:
 
   config.middleware.use 'Rack::ParamToCookie', 'ref' => {}
-  
+
 This tells Rack::ParamToCookie to capture a request parameter called +ref+, store it in a cookie called +ref+, and make it available in your rails app as <tt>request.env['ref']</tt>. You can specify multiple parameters and configure them. Here's a more in-depth example:
 
   config.middleware.use 'Rack::ParamToCookie',
     'ref' => {cookie_name: 'referral_code',
               env_name: 'referral.code',
-              ttl: 14*24*60*60},
+              ttl: 14*24*60*60,
+              max_length: 12},
     'aff' => {cookie_name: 'affiliate_code',
               env_name: 'affiliate.code'}
 
-The first cookie, +referral_code+ for parameter +ref+, has a 14 day time to live and is accessible in +request.env+ <tt>['referral.code']</tt>. The second, for parameter +aff+, has the default time to live, which is 30 days.
+The first cookie, +referral_code+ for parameter +ref+, has a 14 day time to live, can be a maximum of 12 characters and is accessible in +request.env+ <tt>['referral.code']</tt>. The second, for parameter +aff+, has the default time to live, which is 30 days and can be the default maximum length, which is 64 characters.
 
 == Installation
 

--- a/lib/rack/param_to_cookie.rb
+++ b/lib/rack/param_to_cookie.rb
@@ -19,6 +19,7 @@ module Rack
         options[:env_name] ||= param
         options[:ttl] ||= 60*60*24*30 # 30 days
         options[:set_cookie_options] ||= {}
+        options[:max_length] ||= 30 # characters
       end
     end
 
@@ -32,6 +33,9 @@ module Rack
 
         # check whether there's a new value for the cookie with this request
         params_value = req.params[param] rescue nil
+
+        # validate the length of the value
+        next if req.params[param].length > options[:max_length] rescue nil
 
         value = params_value || cookie_value
         env[options[:env_name]] = value if value

--- a/lib/rack/param_to_cookie.rb
+++ b/lib/rack/param_to_cookie.rb
@@ -19,7 +19,7 @@ module Rack
         options[:env_name] ||= param
         options[:ttl] ||= 60*60*24*30 # 30 days
         options[:set_cookie_options] ||= {}
-        options[:max_length] ||= 30 # characters
+        options[:max_length] ||= 64 # characters
       end
     end
 
@@ -35,7 +35,8 @@ module Rack
         params_value = req.params[param] rescue nil
 
         # validate the length of the value
-        next if req.params[param].length > options[:max_length] rescue nil
+        params_value = nil if
+          params_value && params_value.length > options[:max_length]
 
         value = params_value || cookie_value
         env[options[:env_name]] = value if value

--- a/lib/rack/param_to_cookie/version.rb
+++ b/lib/rack/param_to_cookie/version.rb
@@ -1,7 +1,7 @@
 module Rack
   class ParamToCookie
     VERSION_MAJOR = 2
-    VERSION_MINOR = 0
+    VERSION_MINOR = 1
     VERSION_PATCH = 0
     VERSION = [VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH].join('.')
   end

--- a/lib/rack/param_to_cookie/version.rb
+++ b/lib/rack/param_to_cookie/version.rb
@@ -1,7 +1,7 @@
 module Rack
   class ParamToCookie
-    VERSION_MAJOR = 2
-    VERSION_MINOR = 1
+    VERSION_MAJOR = 3
+    VERSION_MINOR = 0
     VERSION_PATCH = 0
     VERSION = [VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH].join('.')
   end

--- a/test/rack/param_to_cookie/param_to_cookie_test.rb
+++ b/test/rack/param_to_cookie/param_to_cookie_test.rb
@@ -60,7 +60,8 @@ describe "Rack::ParamToCookie" do
   describe "with multiple parameters and custom names" do
     before do
       make_app \
-        'ref' => {cookie_name: 'ref_cookie', env_name: 'ref.env', ttl: 10},
+        'ref' => {cookie_name: 'ref_cookie', env_name: 'ref.env', ttl: 10,
+                  max_length: 10},
         'aff' => {cookie_name: 'aff_cookie', env_name: 'aff.env', ttl: 20}
       clear_cookies
     end
@@ -130,6 +131,11 @@ describe "Rack::ParamToCookie" do
       assert_equal({'ref_cookie' => 'baz', 'aff_cookie' => 'bat'},
                    rack_mock_session.cookie_jar.to_hash)
       assert_equal nil, last_response.headers['Set-Cookie']
+    end
+
+    it "should not set cookies longer than the max length" do
+      get '/', ref: 'abcdefghijklmnopqrstuvwxyz'
+      assert_equal({}, rack_mock_session.cookie_jar.to_hash)
     end
   end
 end


### PR DESCRIPTION
Adds the ability to restrict the max length of a param to store as a cookie. This prevents arbitrarily long strings being stored as cookies and potentially being stored by an application at some point. 

I've set the default value of `max_length` to 30 and updated the minor version to reflect this change.